### PR TITLE
only hide font panel if it was for _this_ picker

### DIFF
--- a/Sources/FontPicker/FontPicker.swift
+++ b/Sources/FontPicker/FontPicker.swift
@@ -39,7 +39,10 @@ public struct FontPicker: View {
             Button {
                 if NSFontPanel.shared.isVisible {
                     NSFontPanel.shared.orderOut(nil)
-                    return
+                    
+                    if NSFontManager.shared.target === self.fontPickerDelegate {
+                        return
+                    }
                 }
                 
                 self.fontPickerDelegate = FontPickerDelegate(self)


### PR DESCRIPTION
Previously, if you had two `FontPicker`s, and clicked one, then the other, the font panel would disappear again, rather than show the panel tied to the _new_ button.