### PR TITLE
feat: change the title to optional LocalizedString

### DIFF
--- a/Sources/FontPicker/FontPicker.swift
+++ b/Sources/FontPicker/FontPicker.swift
@@ -22,19 +22,23 @@ class FontPickerDelegate {
 }
 
 public struct FontPicker: View {
-    let labelString: String
+    let label: LocalizedStringKey?
     
     @Binding var font: NSFont
-    @State var fontPickerDelegate: FontPickerDelegate? = nil
+    @State var fontPickerDelegate: FontPickerDelegate?
     
-    public init(_ label: String, selection: Binding<NSFont>) {
-        self.labelString = label
+    public init(_ titlekey: LocalizedStringKey? = nil, selection: Binding<NSFont>) {
+        self.label = titlekey
         self._font = selection
     }
     
     public var body: some View {
         HStack {
-            Text(labelString)
+            if let label {
+                Text(label)
+            } else {
+                EmptyView()
+            }
             
             Button {
                 if NSFontPanel.shared.isVisible {
@@ -65,6 +69,9 @@ public struct FontPicker: View {
 
 struct FontPicker_Previews: PreviewProvider {
     static var previews: some View {
-        FontPicker("font", selection: .constant(NSFont.systemFont(ofSize: 24)))
+        Group {
+            FontPicker("font", selection: .constant(NSFont.systemFont(ofSize: 24)))
+            FontPicker(selection: .constant(NSFont.systemFont(ofSize: 24)))
+        }
     }
 }


### PR DESCRIPTION
- SwiftUIでフォントを設定するための実装を探していてたどり着きました。とても参考になりました、ありがとうございます！
- 細かい所で恐縮ですが、タイトルを任意のLocalizedStringを渡すのはどうでしょうか。名称等はPickerのイニシャライザを参考にしています。
    - [init\(\_:selection:content:\)](https://developer.apple.com/documentation/swiftui/picker/init(_:selection:content:)-6lwfn)